### PR TITLE
RCA-51: Интеграционное тестирование

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -71,6 +71,17 @@ android {
             isReturnDefaultValues = true
         }
     }
+
+    packaging {
+        resources {
+            excludes += "META-INF/LICENSE.md"
+            excludes += "META-INF/LICENSE-notice.md"
+            excludes += "META-INF/AL2.0"
+            excludes += "META-INF/LGPL2.1"
+            excludes += "META-INF/*.version"
+            excludes += "META-INF/DEPENDENCIES"
+        }
+    }
 }
 
 
@@ -123,6 +134,16 @@ dependencies {
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
+
+    // Интеграционные тесты (androidTest)
+    androidTestImplementation(libs.room.testing)
+    androidTestImplementation(libs.hilt.android.testing)
+    androidTestImplementation(libs.mockwebserver)
+    androidTestImplementation(libs.coroutines.test)
+    androidTestImplementation(libs.turbine)
+
+    // Hilt compiler для androidTest
+    kspAndroidTest(libs.hilt.compiler)
 }
 
 configurations.all {

--- a/app/src/androidTest/java/com/yourcompany/recipecomposeapp/features/core/utils/FavoritesDataStoreTest.kt
+++ b/app/src/androidTest/java/com/yourcompany/recipecomposeapp/features/core/utils/FavoritesDataStoreTest.kt
@@ -1,0 +1,187 @@
+package com.yourcompany.recipecomposeapp.features.core.utils
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.cash.turbine.test
+import com.yourcompany.recipecomposeapp.core.utils.FavoriteDataStoreManager
+import com.yourcompany.recipecomposeapp.core.utils.dataStore
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class FavoritesDataStoreTest {
+
+    private lateinit var context: Context
+    private lateinit var manager: FavoriteDataStoreManager
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        manager = FavoriteDataStoreManager(context)
+    }
+
+    @After
+    fun tearDown() = runTest {
+        context.dataStore.edit { preferences ->
+            preferences.clear()
+        }
+    }
+
+    @Test
+    fun addFavoriteSavesRecipeId() = runTest {
+        manager.addFavorite(42)
+
+        val favorites = manager.getAllFavorites()
+        assertTrue(favorites.contains("42"))
+        assertTrue(manager.isFavorite(42))
+    }
+
+    @Test
+    fun addMultipleFavoritesSavesAllIds() = runTest {
+        val recipeIds = listOf(1, 2, 3, 4, 5)
+        recipeIds.forEach { manager.addFavorite(it) }
+
+        val favorites = manager.getAllFavorites()
+        assertEquals(5, favorites.size)
+        recipeIds.forEach { id ->
+            assertTrue(favorites.contains(id.toString()))
+        }
+    }
+
+    @Test
+    fun removeFromFavoritesDeletesRecipeId() = runTest {
+        manager.addFavorite(100)
+        assertTrue(manager.isFavorite(100))
+
+        manager.removeFavorite(100)
+
+        assertFalse(manager.isFavorite(100))
+        assertTrue(manager.getAllFavorites().isEmpty())
+    }
+
+    @Test
+    fun toggleFavoriteSwitchesStateCorrectly() = runTest {
+        val recipeId = 200
+        assertFalse(manager.isFavorite(recipeId))
+
+        manager.toggleFavorite(recipeId)
+        assertTrue(manager.isFavorite(recipeId))
+
+        manager.toggleFavorite(recipeId)
+        assertFalse(manager.isFavorite(recipeId))
+    }
+
+    @Test
+    fun favoritesFlowEmitsUpdatesReactively() = runTest {
+        manager.getFavoriteIdsFlow().test {
+            val initial = awaitItem()
+            assertTrue(initial.isEmpty())
+
+            manager.addFavorite(300)
+            val afterFirstAdd = awaitItem()
+            assertEquals(1, afterFirstAdd.size)
+            assertTrue(afterFirstAdd.contains("300"))
+
+            manager.addFavorite(301)
+            val afterSecondAdd = awaitItem()
+            assertEquals(2, afterSecondAdd.size)
+
+            manager.removeFavorite(300)
+            val afterRemove = awaitItem()
+            assertEquals(1, afterRemove.size)
+            assertTrue(afterRemove.contains("301"))
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun getFavoriteCountFlowEmitsCorrectCount() = runTest {
+        manager.getFavoriteCountFlow().test {
+
+            var count = awaitItem()
+            assertEquals(0, count)
+
+            manager.addFavorite(10)
+            count = awaitItem()
+            assertEquals(1, count)
+
+            manager.addFavorite(20)
+            count = awaitItem()
+            assertEquals(2, count)
+
+            manager.addFavorite(30)
+            count = awaitItem()
+            assertEquals(3, count)
+
+            manager.removeFavorite(20)
+            count = awaitItem()
+            assertEquals(2, count)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun isFavoriteFlowEmitsCorrectValues() = runTest {
+        val recipeId = 500
+
+        manager.isFavoriteFlow(recipeId).test {
+            val initial = awaitItem()
+            assertFalse(initial)
+
+            manager.addFavorite(recipeId)
+            val afterAdd = awaitItem()
+            assertTrue(afterAdd)
+
+            manager.removeFavorite(recipeId)
+            val afterRemove = awaitItem()
+            assertFalse(afterRemove)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun addFavoriteWithDuplicateIdDoesNotDuplicate() = runTest {
+        val recipeId = 999
+
+        manager.addFavorite(recipeId)
+        manager.addFavorite(recipeId)
+
+        val favorites = manager.getAllFavorites()
+        assertEquals(1, favorites.size)
+        assertTrue(favorites.contains(recipeId.toString()))
+    }
+
+    @Test
+    fun removeNonExistentFavoriteDoesNothing() = runTest {
+        val recipeId = 777
+        val initialFavorites = manager.getAllFavorites()
+
+        manager.removeFavorite(recipeId)
+
+        val afterRemoval = manager.getAllFavorites()
+        assertEquals(initialFavorites.size, afterRemoval.size)
+        assertFalse(manager.isFavorite(recipeId))
+    }
+
+    @Test
+    fun getAllFavoritesReturnsCurrentState() = runTest {
+        val recipeIds = setOf(111, 222, 333)
+
+        recipeIds.forEach { manager.addFavorite(it) }
+        val favorites = manager.getAllFavorites()
+
+        assertEquals(3, favorites.size)
+        recipeIds.forEach { id ->
+            assertTrue(favorites.contains(id.toString()))
+        }
+    }
+}

--- a/app/src/androidTest/java/com/yourcompany/recipecomposeapp/features/core/utils/FavoritesDataStoreTest.kt
+++ b/app/src/androidTest/java/com/yourcompany/recipecomposeapp/features/core/utils/FavoritesDataStoreTest.kt
@@ -7,6 +7,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import com.yourcompany.recipecomposeapp.core.utils.FavoriteDataStoreManager
 import com.yourcompany.recipecomposeapp.core.utils.dataStore
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.*
@@ -27,9 +28,11 @@ class FavoritesDataStoreTest {
     }
 
     @After
-    fun tearDown() = runTest {
-        context.dataStore.edit { preferences ->
-            preferences.clear()
+    fun tearDown() {
+        runBlocking {
+            context.dataStore.edit { preferences ->
+                preferences.clear()
+            }
         }
     }
 

--- a/app/src/androidTest/java/com/yourcompany/recipecomposeapp/features/data/database/dao/RecipesDaoTest.kt
+++ b/app/src/androidTest/java/com/yourcompany/recipecomposeapp/features/data/database/dao/RecipesDaoTest.kt
@@ -1,0 +1,144 @@
+package com.yourcompany.recipecomposeapp.features.data.database.dao
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.yourcompany.recipecomposeapp.data.database.RecipesDatabase
+import com.yourcompany.recipecomposeapp.data.database.entity.CategoryEntity
+import com.yourcompany.recipecomposeapp.data.database.entity.RecipeEntity
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.IOException
+
+@RunWith(AndroidJUnit4::class)
+class RecipesDaoTest {
+
+    private lateinit var database: RecipesDatabase
+    private lateinit var categoryDao: com.yourcompany.recipecomposeapp.data.database.dao.CategoryDao
+    private lateinit var recipeDao: com.yourcompany.recipecomposeapp.data.database.dao.RecipeDao
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        database = Room.inMemoryDatabaseBuilder(context, RecipesDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+
+        categoryDao = database.categoryDao()
+        recipeDao = database.recipeDao()
+    }
+
+    @After
+    @Throws(IOException::class)
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun insertsAndRetrievesCategories() = runTest {
+        val categories = listOf(
+            CategoryEntity(1, "Завтраки", "Лёгкие завтраки", "breakfast.jpg"),
+            CategoryEntity(2, "Обеды", "Сытные обеды", "lunch.jpg")
+        )
+
+        categoryDao.insertCategories(categories)
+        val retrieved = categoryDao.getAllCategories().first()
+
+        assertEquals(2, retrieved.size)
+    }
+
+    @Test
+    fun insertReplacesDuplicateCategory() = runTest {
+        val originalCategory =
+            CategoryEntity(1, "Завтраки", "Оригинальное описание", "breakfast.jpg")
+        categoryDao.insertCategory(originalCategory)
+
+        val updatedCategory =
+            CategoryEntity(1, "Завтраки и бранчи", "Обновленное описание", "updated_breakfast.jpg")
+        categoryDao.insertCategory(updatedCategory)
+
+        val allCategories = categoryDao.getAllCategories().first()
+        assertEquals(1, allCategories.size)
+
+        val retrieved = categoryDao.getCategoryById(1)
+        assertEquals("Завтраки и бранчи", retrieved?.name)
+    }
+
+    @Test
+    fun getRecipesByCategoryReturnsCorrectItems() = runTest {
+        val category1 = CategoryEntity(1, "Завтраки", "Описание", "img1.jpg")
+        val category2 = CategoryEntity(2, "Обеды", "Описание", "img2.jpg")
+        categoryDao.insertCategory(category1)
+        categoryDao.insertCategory(category2)
+
+        val recipes = listOf(
+            RecipeEntity(1, "Овсяная каша", 1, "oatmeal.jpg", "[]", "[]", 2),
+            RecipeEntity(2, "Яичница", 1, "eggs.jpg", "[]", "[]", 1),
+            RecipeEntity(3, "Борщ", 2, "borscht.jpg", "[]", "[]", 4)
+        )
+
+        recipeDao.insertRecipes(recipes)
+        val recipesForCategory1 = recipeDao.getRecipesByCategory(1).first()
+
+        assertEquals(2, recipesForCategory1.size)
+        assertTrue(recipesForCategory1.all { it.categoryId == 1 })
+    }
+
+    @Test
+    fun emptyDatabaseReturnsEmptyList() = runTest {
+        val categories = categoryDao.getAllCategories().first()
+        val recipes = recipeDao.getRecipesByCategory(1).first()
+
+        assertTrue(categories.isEmpty())
+        assertTrue(recipes.isEmpty())
+        assertEquals(0, categoryDao.getCategoriesCount())
+    }
+
+    @Test
+    fun getCategoryByIdReturnsCorrectCategory() = runTest {
+        val category = CategoryEntity(42, "Десерты", "Сладкие десерты", "desserts.jpg")
+        categoryDao.insertCategory(category)
+
+        val retrieved = categoryDao.getCategoryById(42)
+
+        assertEquals(42, retrieved?.id)
+        assertEquals("Десерты", retrieved?.name)
+    }
+
+    @Test
+    fun deleteAllCategoriesClearsTable() = runTest {
+        val categories = listOf(
+            CategoryEntity(1, "Категория 1", "Описание 1", "img1.jpg"),
+            CategoryEntity(2, "Категория 2", "Описание 2", "img2.jpg")
+        )
+        categoryDao.insertCategories(categories)
+        assertEquals(2, categoryDao.getCategoriesCount())
+
+        categoryDao.deleteAllCategories()
+
+        assertEquals(0, categoryDao.getCategoriesCount())
+        assertTrue(categoryDao.getAllCategories().first().isEmpty())
+    }
+
+    @Test
+    fun getRecipeByIdReturnsFlowWithUpdates() = runTest {
+        val category = CategoryEntity(1, "Завтраки", "Описание", "img.jpg")
+        categoryDao.insertCategory(category)
+
+        val recipe = RecipeEntity(100, "Первоначальное название", 1, "recipe.jpg", "[]", "[]", 2)
+        recipeDao.insertRecipe(recipe)
+
+        val updatedRecipe = recipe.copy(title = "Обновленное название")
+        recipeDao.insertRecipe(updatedRecipe)
+
+        val result = recipeDao.getRecipeById(100).first()
+        assertEquals("Обновленное название", result?.title)
+    }
+}

--- a/app/src/androidTest/java/com/yourcompany/recipecomposeapp/features/data/repository/RecipesRepositoryIntegrationTest.kt
+++ b/app/src/androidTest/java/com/yourcompany/recipecomposeapp/features/data/repository/RecipesRepositoryIntegrationTest.kt
@@ -13,7 +13,7 @@ import com.yourcompany.recipecomposeapp.data.repository.RecipesRepositoryImpl
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.ExperimentalSerializationApi
@@ -47,6 +47,8 @@ class RecipesRepositoryIntegrationTest {
     private lateinit var apiService: RecipesApiService
     private lateinit var repository: RecipesRepositoryImpl
 
+    private val testDispatcher = StandardTestDispatcher()
+
     @Before
     fun setup() {
         val context = ApplicationProvider.getApplicationContext<Context>()
@@ -65,7 +67,6 @@ class RecipesRepositoryIntegrationTest {
             .build()
 
         apiService = retrofit.create(RecipesApiService::class.java)
-
     }
 
     @After
@@ -75,11 +76,11 @@ class RecipesRepositoryIntegrationTest {
     }
 
     @Test
-    fun savesDataToCacheAfterSuccessfulApiCall() = runTest {
+    fun savesDataToCacheAfterSuccessfulApiCall() = runTest(testDispatcher) {
         repository = RecipesRepositoryImpl(
             apiService = apiService,
             database = database,
-            externalScope = CoroutineScope(this.coroutineContext)
+            externalScope = CoroutineScope(testDispatcher)  // ← ключевое изменение!
         )
 
         val expectedCategories = listOf(
@@ -113,11 +114,11 @@ class RecipesRepositoryIntegrationTest {
     }
 
     @Test
-    fun returnsCachedDataWhenApiFails() = runTest {
+    fun returnsCachedDataWhenApiFails() = runTest(testDispatcher) {
         repository = RecipesRepositoryImpl(
             apiService = apiService,
             database = database,
-            externalScope = CoroutineScope(this.coroutineContext)
+            externalScope = CoroutineScope(testDispatcher)
         )
 
         val cachedCategories = listOf(

--- a/app/src/androidTest/java/com/yourcompany/recipecomposeapp/features/data/repository/RecipesRepositoryIntegrationTest.kt
+++ b/app/src/androidTest/java/com/yourcompany/recipecomposeapp/features/data/repository/RecipesRepositoryIntegrationTest.kt
@@ -1,0 +1,138 @@
+package com.yourcompany.recipecomposeapp.features.data.repository
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import com.yourcompany.recipecomposeapp.core.network.api.RecipesApiService
+import com.yourcompany.recipecomposeapp.data.database.RecipesDatabase
+import com.yourcompany.recipecomposeapp.data.database.entity.CategoryEntity
+import com.yourcompany.recipecomposeapp.data.model.CategoryDto
+import com.yourcompany.recipecomposeapp.data.repository.RecipesRepositoryImpl
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import retrofit2.Retrofit
+
+private val sharedJson = Json {
+    ignoreUnknownKeys = true
+    coerceInputValues = true
+    isLenient = true
+    explicitNulls = false
+}
+
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalSerializationApi::class)
+@RunWith(AndroidJUnit4::class)
+class RecipesRepositoryIntegrationTest {
+
+    private lateinit var database: RecipesDatabase
+    private lateinit var mockWebServer: MockWebServer
+    private lateinit var apiService: RecipesApiService
+    private lateinit var repository: RecipesRepositoryImpl
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+
+        val context = ApplicationProvider.getApplicationContext<Context>()
+
+        database = Room.inMemoryDatabaseBuilder(context, RecipesDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+
+        mockWebServer = MockWebServer()
+        mockWebServer.start()
+
+        val retrofit = Retrofit.Builder()
+            .baseUrl(mockWebServer.url("/"))
+            .client(OkHttpClient.Builder().build())
+            .addConverterFactory(sharedJson.asConverterFactory("application/json".toMediaType()))
+            .build()
+
+        apiService = retrofit.create(RecipesApiService::class.java)
+        repository = RecipesRepositoryImpl(apiService, database)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        database.close()
+        mockWebServer.shutdown()
+    }
+
+    @Test
+    fun savesDataToCacheAfterSuccessfulApiCall() = runTest {
+        val expectedCategories = listOf(
+            CategoryDto(1, "Завтраки", "Лёгкие завтраки", "breakfast.jpg"),
+            CategoryDto(2, "Обеды", "Сытные обеды", "lunch.jpg")
+        )
+
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(sharedJson.encodeToString(expectedCategories))
+                .addHeader("Content-Type", "application/json")
+        )
+
+        val resultFlow = repository.getCategories()
+
+        val firstResult = resultFlow.first()
+        assertTrue(firstResult.isEmpty())
+
+        advanceUntilIdle()
+
+        val cachedCategories = database.categoryDao().getAllCategories().first()
+        assertEquals("Данные не сохранились в БД", 2, cachedCategories.size)
+        assertEquals("Завтраки", cachedCategories[0].name)
+        assertEquals("Обеды", cachedCategories[1].name)
+
+        val finalResult = resultFlow.first()
+        assertEquals(2, finalResult.size)
+        assertEquals("Завтраки", finalResult[0].title)
+        assertEquals("Обеды", finalResult[1].title)
+    }
+
+    @Test
+    fun returnsCachedDataWhenApiFails() = runTest {
+        val cachedCategories = listOf(
+            CategoryEntity(1, "Кешированные завтраки", "Описание", "img1.jpg"),
+            CategoryEntity(2, "Кешированные обеды", "Описание", "img2.jpg")
+        )
+        database.categoryDao().insertCategories(cachedCategories)
+
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(500)
+                .setBody("Internal Server Error")
+        )
+
+        val resultFlow = repository.getCategories()
+
+        val result = resultFlow.first()
+        assertEquals(2, result.size)
+        assertEquals("Кешированные завтраки", result[0].title)
+        assertEquals("Кешированные обеды", result[1].title)
+    }
+}

--- a/app/src/androidTest/java/com/yourcompany/recipecomposeapp/features/data/repository/RecipesRepositoryIntegrationTest.kt
+++ b/app/src/androidTest/java/com/yourcompany/recipecomposeapp/features/data/repository/RecipesRepositoryIntegrationTest.kt
@@ -80,7 +80,7 @@ class RecipesRepositoryIntegrationTest {
         repository = RecipesRepositoryImpl(
             apiService = apiService,
             database = database,
-            externalScope = CoroutineScope(testDispatcher)  // ← ключевое изменение!
+            externalScope = CoroutineScope(testDispatcher)
         )
 
         val expectedCategories = listOf(

--- a/app/src/androidTest/java/com/yourcompany/recipecomposeapp/features/data/repository/RecipesRepositoryIntegrationTest.kt
+++ b/app/src/androidTest/java/com/yourcompany/recipecomposeapp/features/data/repository/RecipesRepositoryIntegrationTest.kt
@@ -10,15 +10,12 @@ import com.yourcompany.recipecomposeapp.data.database.RecipesDatabase
 import com.yourcompany.recipecomposeapp.data.database.entity.CategoryEntity
 import com.yourcompany.recipecomposeapp.data.model.CategoryDto
 import com.yourcompany.recipecomposeapp.data.repository.RecipesRepositoryImpl
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import kotlinx.coroutines.withContext
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -50,12 +47,8 @@ class RecipesRepositoryIntegrationTest {
     private lateinit var apiService: RecipesApiService
     private lateinit var repository: RecipesRepositoryImpl
 
-    private val testDispatcher = StandardTestDispatcher()
-
     @Before
     fun setup() {
-        Dispatchers.setMain(testDispatcher)
-
         val context = ApplicationProvider.getApplicationContext<Context>()
 
         database = Room.inMemoryDatabaseBuilder(context, RecipesDatabase::class.java)
@@ -72,18 +65,23 @@ class RecipesRepositoryIntegrationTest {
             .build()
 
         apiService = retrofit.create(RecipesApiService::class.java)
-        repository = RecipesRepositoryImpl(apiService, database)
+
     }
 
     @After
     fun tearDown() {
-        Dispatchers.resetMain()
         database.close()
         mockWebServer.shutdown()
     }
 
     @Test
     fun savesDataToCacheAfterSuccessfulApiCall() = runTest {
+        repository = RecipesRepositoryImpl(
+            apiService = apiService,
+            database = database,
+            externalScope = CoroutineScope(this.coroutineContext)
+        )
+
         val expectedCategories = listOf(
             CategoryDto(1, "Завтраки", "Лёгкие завтраки", "breakfast.jpg"),
             CategoryDto(2, "Обеды", "Сытные обеды", "lunch.jpg")
@@ -116,6 +114,12 @@ class RecipesRepositoryIntegrationTest {
 
     @Test
     fun returnsCachedDataWhenApiFails() = runTest {
+        repository = RecipesRepositoryImpl(
+            apiService = apiService,
+            database = database,
+            externalScope = CoroutineScope(this.coroutineContext)
+        )
+
         val cachedCategories = listOf(
             CategoryEntity(1, "Кешированные завтраки", "Описание", "img1.jpg"),
             CategoryEntity(2, "Кешированные обеды", "Описание", "img2.jpg")
@@ -129,6 +133,8 @@ class RecipesRepositoryIntegrationTest {
         )
 
         val resultFlow = repository.getCategories()
+
+        advanceUntilIdle()
 
         val result = resultFlow.first()
         assertEquals(2, result.size)

--- a/app/src/main/java/com/yourcompany/recipecomposeapp/data/repository/RecipesRepositoryImpl.kt
+++ b/app/src/main/java/com/yourcompany/recipecomposeapp/data/repository/RecipesRepositoryImpl.kt
@@ -23,7 +23,8 @@ import javax.inject.Singleton
 @Singleton
 class RecipesRepositoryImpl @Inject constructor(
     private val apiService: RecipesApiService,
-    private val database: RecipesDatabase
+    private val database: RecipesDatabase,
+    private val externalScope: CoroutineScope = CoroutineScope(Dispatchers.IO)
 ) : RecipesRepository {
 
     private companion object {
@@ -36,8 +37,6 @@ class RecipesRepositoryImpl @Inject constructor(
     private val recipesCache = mutableMapOf<Int, List<RecipeDto>>()
     private val cacheMutex = Mutex()
     private var categoriesCache: List<CategoryDto>? = null
-
-    private val refreshScope = CoroutineScope(Dispatchers.IO)
 
     override suspend fun forceLoadRecipe(recipeId: Int): RecipeDto? {
         return withContext(Dispatchers.IO) {
@@ -89,7 +88,7 @@ class RecipesRepositoryImpl @Inject constructor(
 
     override fun getCategories(): Flow<List<CategoryDto>> {
 
-        refreshScope.launch {
+        externalScope.launch {
             try {
                 Log.d(TAG, "Запуск фонового обновления категорий из API")
                 val freshCategories = apiService.getCategories()
@@ -114,7 +113,7 @@ class RecipesRepositoryImpl @Inject constructor(
 
     override fun getRecipesByCategory(categoryId: Int): Flow<List<RecipeDto>> {
 
-        refreshScope.launch {
+        externalScope.launch {
             try {
                 Log.d(TAG, "Запуск фонового обновления рецептов для категории $categoryId")
                 val freshRecipes = apiService.getRecipesByCategory(categoryId)
@@ -140,7 +139,7 @@ class RecipesRepositoryImpl @Inject constructor(
     }
 
     override fun getRecipe(recipeId: Int): Flow<RecipeDto?> {
-        refreshScope.launch {
+        externalScope.launch {
             try {
                 val existingEntity = recipeDao.getRecipeByIdSync(recipeId)
 

--- a/app/src/main/java/com/yourcompany/recipecomposeapp/di/CoroutineScopeModule.kt
+++ b/app/src/main/java/com/yourcompany/recipecomposeapp/di/CoroutineScopeModule.kt
@@ -1,0 +1,21 @@
+package com.yourcompany.recipecomposeapp.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object CoroutineScopeModule {
+
+    @Provides
+    @Singleton
+    fun provideCoroutineScope(): CoroutineScope {
+        return CoroutineScope(Dispatchers.IO + SupervisorJob())
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -68,6 +68,9 @@ mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines-test" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4", version.ref = "uiTestJunit4" }
+mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp" }
+room-testing = { module = "androidx.room:room-testing", version.ref = "room" }
+hilt-android-testing = { module = "com.google.dagger:hilt-android-testing", version.ref = "hilt" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
1. Настроены зависимости для интеграционного тестирования
   - libs.versions.toml: добавлены mockwebserver, room-testing, hilt-android-testing
   - app/build.gradle.kts: добавлены androidTestImplementation зависимости и kspAndroidTest

2. Добавлены тесты Room DAO (RecipesDaoTest.kt):

   * insertsAndRetrievesCategories - проверка вставки и чтения категорий
   * insertReplacesDuplicateCategory - проверка замены дубликатов
   * getRecipesByCategoryReturnsCorrectItems - фильтрация рецептов по категории
   * emptyDatabaseReturnsEmptyList - поведение с пустой БД
   * getCategoryByIdReturnsCorrectCategory - поиск категории по ID
   * deleteAllCategoriesClearsTable - очистка таблицы категорий
   * getRecipeByIdReturnsFlowWithUpdates - реактивность Flow при обновлении

3. Добавлены тесты DataStore (FavoritesDataStoreTest.kt):

   * addFavoriteSavesRecipeId - сохранение ID в избранное
   * addMultipleFavoritesSavesAllIds - сохранение нескольких ID
   * removeFromFavoritesDeletesRecipeId - удаление из избранного
   * toggleFavoriteSwitchesStateCorrectly - переключение состояния
   * favoritesFlowEmitsUpdatesReactively - реактивность Flow
   * getFavoriteCountFlowEmitsCorrectCount - подсчёт количества
   * isFavoriteFlowEmitsCorrectValues - проверка статуса через Flow
   * addFavoriteWithDuplicateIdDoesNotDuplicate - защита от дубликатов
   * removeNonExistentFavoriteDoesNothing - удаление несуществующего
   * getAllFavoritesReturnsCurrentState - получение всех избранных

4. Добавлены интеграционные тесты Repository (RecipesRepositoryIntegrationTest.kt):

   * savesDataToCacheAfterSuccessfulApiCall - кеширование данных из API
   * returnsCachedDataWhenApiFails - возврат кеша при ошибке API