### PR TITLE
RCA-52: UI-тестирование с Kaspresso

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -144,6 +144,13 @@ dependencies {
 
     // Hilt compiler для androidTest
     kspAndroidTest(libs.hilt.compiler)
+
+    androidTestImplementation(libs.kaspresso)
+    androidTestImplementation(libs.kaspresso.compose)
+
+    androidTestImplementation(libs.androidx.test.runner)
+    androidTestImplementation(libs.androidx.test.rules)
+    androidTestImplementation(libs.androidx.test.core)
 }
 
 configurations.all {

--- a/app/src/androidTest/java/com/yourcompany/recipecomposeapp/features/CategoriesE2ETest.kt
+++ b/app/src/androidTest/java/com/yourcompany/recipecomposeapp/features/CategoriesE2ETest.kt
@@ -1,0 +1,51 @@
+package com.yourcompany.recipecomposeapp.features
+
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import com.kaspersky.components.composesupport.config.withComposeSupport
+import com.kaspersky.kaspresso.kaspresso.Kaspresso
+import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
+import com.yourcompany.recipecomposeapp.MainActivity
+import com.yourcompany.recipecomposeapp.features.screens.CategoriesComposeScreen
+import com.yourcompany.recipecomposeapp.features.screens.RecipesComposeScreen
+import io.github.kakaocup.compose.node.element.ComposeScreen.Companion.onComposeScreen
+import org.junit.Rule
+import org.junit.Test
+
+class CategoriesE2ETest : TestCase(
+    kaspressoBuilder = Kaspresso.Builder.withComposeSupport()
+) {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    @Test
+    fun categoriesScreenLoadsContent() = run {
+        step("Дождаться загрузки и проверить отображение сетки категорий") {
+            onComposeScreen<CategoriesComposeScreen>(composeTestRule) {
+                categoriesGrid { assertIsDisplayed() }
+            }
+        }
+    }
+
+    @Test
+    fun clickingCategoryOpensRecipesScreen() = run {
+        step("Дождаться загрузки сетки категорий") {
+            onComposeScreen<CategoriesComposeScreen>(composeTestRule) {
+                categoriesGrid { assertIsDisplayed() }
+            }
+        }
+
+        step("Нажать на первую категорию") {
+            onComposeScreen<CategoriesComposeScreen>(composeTestRule) {
+                categoryItem { performClick() }
+            }
+        }
+
+        step("Проверить, что открылся экран рецептов и отображается список") {
+            onComposeScreen<RecipesComposeScreen>(composeTestRule) {
+                assertIsDisplayed()
+                recipesList { assertIsDisplayed() }
+            }
+        }
+    }
+}

--- a/app/src/androidTest/java/com/yourcompany/recipecomposeapp/features/data/repository/RecipesRepositoryIntegrationTest.kt
+++ b/app/src/androidTest/java/com/yourcompany/recipecomposeapp/features/data/repository/RecipesRepositoryIntegrationTest.kt
@@ -80,7 +80,8 @@ class RecipesRepositoryIntegrationTest {
         repository = RecipesRepositoryImpl(
             apiService = apiService,
             database = database,
-            externalScope = CoroutineScope(testDispatcher)
+            externalScope = CoroutineScope(testDispatcher),
+            ioDispatcher = testDispatcher
         )
 
         val expectedCategories = listOf(

--- a/app/src/androidTest/java/com/yourcompany/recipecomposeapp/features/screens/CategoriesComposeScreen.kt
+++ b/app/src/androidTest/java/com/yourcompany/recipecomposeapp/features/screens/CategoriesComposeScreen.kt
@@ -1,0 +1,20 @@
+package com.yourcompany.recipecomposeapp.features.screens
+
+import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
+import com.kaspersky.kaspresso.kaspresso.Kaspresso
+import io.github.kakaocup.compose.node.element.ComposeScreen
+import io.github.kakaocup.compose.node.element.KNode
+
+class CategoriesComposeScreen(
+    semanticsProvider: SemanticsNodeInteractionsProvider
+) : ComposeScreen<CategoriesComposeScreen>(
+    semanticsProvider = semanticsProvider,
+    viewBuilderAction = { hasTestTag("categories_screen") }
+) {
+    val loadingIndicator: KNode = child { hasTestTag("loading_indicator") }
+    val categoriesGrid: KNode = child { hasTestTag("categories_grid") }
+    val categoryItem: KNode = child { hasTestTag("category_item") }
+    val errorMessage: KNode = child { hasTestTag("error_message") }
+    val emptyState: KNode = child { hasTestTag("empty_state") }
+    val retryButton: KNode = child { hasText("Повторить") }
+}

--- a/app/src/androidTest/java/com/yourcompany/recipecomposeapp/features/screens/RecipesComposeScreen.kt
+++ b/app/src/androidTest/java/com/yourcompany/recipecomposeapp/features/screens/RecipesComposeScreen.kt
@@ -1,0 +1,20 @@
+package com.yourcompany.recipecomposeapp.features.screens
+
+import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
+import com.kaspersky.kaspresso.kaspresso.Kaspresso
+import io.github.kakaocup.compose.node.element.ComposeScreen
+import io.github.kakaocup.compose.node.element.KNode
+
+class RecipesComposeScreen(
+    semanticsProvider: SemanticsNodeInteractionsProvider
+) : ComposeScreen<RecipesComposeScreen>(
+    semanticsProvider = semanticsProvider,
+    viewBuilderAction = { hasTestTag("recipes_screen") }
+) {
+    val loadingIndicator: KNode = child { hasTestTag("loading_indicator") }
+    val emptyState: KNode = child { hasTestTag("empty_state") }
+    val errorMessage: KNode = child { hasTestTag("error_message") }
+    val retryButton: KNode = child { hasText("Повторить") }
+    val recipesList: KNode = child { hasTestTag("recipes_list") }
+    val recipeItem: KNode = child { hasTestTag("recipe_item") }
+}

--- a/app/src/main/java/com/yourcompany/recipecomposeapp/data/repository/RecipesRepositoryImpl.kt
+++ b/app/src/main/java/com/yourcompany/recipecomposeapp/data/repository/RecipesRepositoryImpl.kt
@@ -9,6 +9,7 @@ import com.yourcompany.recipecomposeapp.data.model.CategoryDto
 import com.yourcompany.recipecomposeapp.data.model.RecipeDto
 import com.yourcompany.recipecomposeapp.data.model.toDto
 import com.yourcompany.recipecomposeapp.data.model.toEntity
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -24,7 +25,8 @@ import javax.inject.Singleton
 class RecipesRepositoryImpl @Inject constructor(
     private val apiService: RecipesApiService,
     private val database: RecipesDatabase,
-    private val externalScope: CoroutineScope = CoroutineScope(Dispatchers.IO)
+    private val externalScope: CoroutineScope = CoroutineScope(Dispatchers.IO),
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : RecipesRepository {
 
     private companion object {
@@ -39,7 +41,7 @@ class RecipesRepositoryImpl @Inject constructor(
     private var categoriesCache: List<CategoryDto>? = null
 
     override suspend fun forceLoadRecipe(recipeId: Int): RecipeDto? {
-        return withContext(Dispatchers.IO) {
+        return withContext(ioDispatcher) {
             try {
                 Log.d(TAG, "Принудительная загрузка рецепта $recipeId из API")
 
@@ -93,7 +95,7 @@ class RecipesRepositoryImpl @Inject constructor(
                 Log.d(TAG, "Запуск фонового обновления категорий из API")
                 val freshCategories = apiService.getCategories()
 
-                withContext(Dispatchers.IO) {
+                withContext(ioDispatcher) {
 
                     val categoryEntities = freshCategories.map { it.toEntity() }
                     categoryDao.insertCategories(categoryEntities)
@@ -118,7 +120,7 @@ class RecipesRepositoryImpl @Inject constructor(
                 Log.d(TAG, "Запуск фонового обновления рецептов для категории $categoryId")
                 val freshRecipes = apiService.getRecipesByCategory(categoryId)
 
-                withContext(Dispatchers.IO) {
+                withContext(ioDispatcher) {
 
                     val recipeEntities = freshRecipes.map { it.toEntity(categoryId) }
                     recipeDao.insertRecipes(recipeEntities)
@@ -165,7 +167,7 @@ class RecipesRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getRecipeSync(recipeId: Int): RecipeDto? {
-        return withContext(Dispatchers.IO) {
+        return withContext(ioDispatcher) {
             val entity = recipeDao.getRecipeByIdSync(recipeId)
             entity?.toDto()
         }
@@ -198,7 +200,7 @@ class RecipesRepositoryImpl @Inject constructor(
     }
 
     override suspend fun clearCache() {
-        withContext(Dispatchers.IO) {
+        withContext(ioDispatcher) {
             categoryDao.deleteAllCategories()
             recipeDao.deleteAllRecipes()
 

--- a/app/src/main/java/com/yourcompany/recipecomposeapp/di/CoroutineScopeModule.kt
+++ b/app/src/main/java/com/yourcompany/recipecomposeapp/di/CoroutineScopeModule.kt
@@ -4,6 +4,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -18,4 +19,8 @@ object CoroutineScopeModule {
     fun provideCoroutineScope(): CoroutineScope {
         return CoroutineScope(Dispatchers.IO + SupervisorJob())
     }
+
+    @Provides
+    @Singleton
+    fun provideIoDispatcher(): CoroutineDispatcher = Dispatchers.IO
 }

--- a/app/src/main/java/com/yourcompany/recipecomposeapp/features/categories/ui/CategoriesScreen.kt
+++ b/app/src/main/java/com/yourcompany/recipecomposeapp/features/categories/ui/CategoriesScreen.kt
@@ -48,13 +48,6 @@ fun CategoriesScreen(
     )
 }
 
-/**
- * Stateless composable для тестирования UI экрана категорий
- * @param uiState Состояние UI для отображения
- * @param onCategoryClick Callback при клике на категорию
- * @param onRetry Callback при повторной попытке загрузки
- * @param modifier Модификатор
- */
 @Composable
 fun CategoriesContent(
     uiState: CategoriesUiState,
@@ -66,6 +59,7 @@ fun CategoriesContent(
         modifier = modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
+            .testTag("categories_screen")
     ) {
         ScreenHeader(
             header = "Категории",
@@ -110,6 +104,7 @@ private fun CategoriesGrid(
 ) {
     LazyVerticalGrid(
         columns = GridCells.Fixed(2),
+        modifier = Modifier.testTag("categories_grid"),
         horizontalArrangement = Arrangement.spacedBy(
             dimensionResource(R.dimen.mainPadding)
         ),

--- a/app/src/main/java/com/yourcompany/recipecomposeapp/features/categories/ui/CategoryItem.kt
+++ b/app/src/main/java/com/yourcompany/recipecomposeapp/features/categories/ui/CategoryItem.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -33,7 +34,8 @@ fun CategoryItem(
         modifier = Modifier
             .clickable { onClick() }
             .height(220.dp)
-            .width(156.dp),
+            .width(156.dp)
+            .testTag("category_item"),
         shape = RoundedCornerShape(
             size = dimensionResource(R.dimen.halfBasicCornerRadius)
         ),

--- a/app/src/main/java/com/yourcompany/recipecomposeapp/features/recipes/ui/RecipeItem.kt
+++ b/app/src/main/java/com/yourcompany/recipecomposeapp/features/recipes/ui/RecipeItem.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -30,7 +31,8 @@ fun RecipeItem(
     Card(
         modifier = modifier
             .fillMaxWidth()
-            .clickable { onClick(recipe.id) },
+            .clickable { onClick(recipe.id) }
+            .testTag("recipe_item"),
         shape = RoundedCornerShape(
             size = dimensionResource(R.dimen.basicCornerRadius)
         ),

--- a/app/src/main/java/com/yourcompany/recipecomposeapp/features/recipes/ui/RecipesScreen.kt
+++ b/app/src/main/java/com/yourcompany/recipecomposeapp/features/recipes/ui/RecipesScreen.kt
@@ -67,6 +67,7 @@ fun RecipesContent(
         modifier = modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
+            .testTag("recipes_screen")
     ) {
         ScreenHeader(
             header = uiState.categoryTitle,
@@ -109,7 +110,8 @@ private fun RecipesList(
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background),
+            .background(MaterialTheme.colorScheme.background)
+            .testTag("recipes_list"),
         contentPadding = PaddingValues(
             vertical = dimensionResource(R.dimen.mainPadding)
         ),
@@ -207,8 +209,6 @@ private fun EmptyState() {
         )
     }
 }
-
-// ==================== PREVIEWS ====================
 
 @Preview(showBackground = true, name = "Recipes Screen - Loading State")
 @Composable

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,9 @@ mockk = "1.13.9"
 coroutines-test = "1.7.3"
 turbine = "1.0.0"
 uiTestJunit4 = "1.10.6"
+kaspresso = "1.5.3"
+testRunner = "1.5.0"
+androidxTestCore = "1.5.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -71,6 +74,11 @@ androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit
 mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp" }
 room-testing = { module = "androidx.room:room-testing", version.ref = "room" }
 hilt-android-testing = { module = "com.google.dagger:hilt-android-testing", version.ref = "hilt" }
+kaspresso = { module = "com.kaspersky.android-components:kaspresso", version.ref = "kaspresso" }
+kaspresso-compose = { module = "com.kaspersky.android-components:kaspresso-compose-support", version.ref = "kaspresso" }
+androidx-test-runner = { module = "androidx.test:runner", version.ref = "testRunner" }
+androidx-test-rules = { module = "androidx.test:rules", version.ref = "testRunner" }
+androidx-test-core = { module = "androidx.test:core", version.ref = "androidxTestCore" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
- Добавлены зависимости kaspresso и kaspresso-compose (версия 1.5.3) в libs.versions.toml и build.gradle.kts.
- Добавлен testInstrumentationRunner и тестовые библиотеки (runner, rules, core).
- Добавлены testTag: categories_screen, category_item, recipes_screen, categories_grid, recipes_list.
- Созданы Screen Objects: CategoriesComposeScreen и RecipesComposeScreen в features.screens.
- Реализованы E2E-тесты в CategoriesE2ETest: • categoriesScreenLoadsContent – проверка отображения сетки категорий. • clickingCategoryOpensRecipesScreen – навигация по категории и проверка открытия экрана рецептов.
- Все тесты успешно проходят, логи Kaspresso выводят шаги.